### PR TITLE
Fixed routing rendering error

### DIFF
--- a/src/router/app-router.tsx
+++ b/src/router/app-router.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
-import { MainLayout } from 'src/layouts';
 import { routes } from './routes';
 
 export const AppRouter: React.FC = () => (
   <Routes>
-    <MainLayout>
-      {routes.map((route) => (
-        <Route key={route.path} path={route.path} element={route.element} />
-      ))}
-    </MainLayout>
+    {routes.map((route) => (
+      <Route key={route.path} path={route.path} element={route.element} />
+    ))}
   </Routes>
 );


### PR DESCRIPTION
Only Route components from the react-router-dom library can be child components in the Routes component